### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Another new feature of Emmet 2 is inline preview of opening tag. When you move c
 
 Click on this preview will jump to open tag.
 
-This option is disable by default. To enable it, go to _Preferences > Package Settings > Emmet > Settings_ and set `tag_preview` option to `true`.
+This option is disabled by default. To enable it, go to _Preferences > Package Settings > Emmet > Settings_ and set `tag_preview` option to `true`.
 
 ## Adding custom Emmet snippets
 
@@ -218,7 +218,7 @@ A convenient way to add key bindings for Emmet commands is to go to _Preferences
 
 Here are some most frequently asked questions and issues users came up with after updating to Emmet v2:
 
-### All my keyboard shortcuts gone/nothing works!
+### All my keyboard shortcuts are gone/nothing works!
 
 Emmet comes with lots of actions like [Wrap with Abbreviation](https://docs.emmet.io/actions/wrap-with-abbreviation/), [Balance](https://docs.emmet.io/actions/match-pair/), [Select Item](https://docs.emmet.io/actions/select-item/) etc. In v1, all these actions had default key bindings. And some of these actions override default ST actions like _Go To End of Line_ (<kbd>Ctrl+E</kbd>) or actions from default packages. Unfortunately, ST doesn’t provide any means to unbind key bindings coming from packages so it became a real problem for users to properly restore editor behavior.
 
@@ -229,7 +229,7 @@ In Emmet 2, all key bindings are disabled by default so you have to add them man
 
 ### <kbd>Tab</kbd> key doesn’t work anymore
 
-Most likely, you’ve updated <kbd>Tab</kbd> key handler for `expand_abbreviation_by_tab` action from Emmet v1 in your key bindings file: simply remove it, it no longer valid.
+Most likely, you’ve updated <kbd>Tab</kbd> key handler for `expand_abbreviation_by_tab` action from Emmet v1 in your key bindings file: simply remove it, it is no longer valid.
 
 ### I don’t like new behavior with abbreviation capturing, I’d like to expand with <kbd>Tab</kbd> as earlier
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Most likely, you’ve updated <kbd>Tab</kbd> key handler for `expand_abbreviatio
 
 You can get almost the same abbreviation expansion behavior as in v1:
 
-* Go to _Preferences > Package Settings > Emmet > Settings_ menu item and set `auto_mark` option to `false`.
+* Go to _Preferences > Package Settings > Emmet > Settings_ menu item and set `tab_expand` option to `false`.
 * Add the following into user key bindings (_Preferences > Key Bindings_ menu item) file:
 
 ```jsonc

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ ul#nav>li.item$*4>a{Item $}
 ## Installation
 
 1. From `Command Palette`, run `Package Control: Install Package` command.
-2. In opened packages list, find `Emmet` package and install it
+2. In opened packages list, find `Emmet` package and install it.
 
-If you’re unable to find `Emmet` package on last step or installed package doesn’t work as expected, restart Sublime Text and try again
+If you’re unable to find `Emmet` package on last step or installed package doesn’t work as expected, restart Sublime Text and try again.
 
 ## Expanding abbreviation
 
@@ -59,7 +59,7 @@ If you used [previous version](https://github.com/sergeche/emmet-sublime) of Emm
 
 In this plugin, abbreviation expander acts as *autocomplete provider* and automatically captures abbreviation as you type.
 
-When you start typing in *Emmet-supported context* (HTML, CSS, Slim etc.) Emmet detects if you’re typing something similar to abbreviation and adds underline which indicates *captured abbreviation*. When captured abbreviation becomes *complex* (e.g. contains attributes or multiple elements), you’ll see a preview of expanded abbreviation every time caret is inside it. Hit <kbd>Tab</kbd>key *inside captured abbreviation* to expand it, hit <kbd>Esc</kbd> to remove mark from abbreviation so you can use <kbd>Tab</kbd> for expanding native ST snippets or insert tab character.
+When you start typing in *Emmet-supported context* (HTML, CSS, Slim etc.) Emmet detects if you’re typing something similar to abbreviation and adds underline which indicates *captured abbreviation*. When captured abbreviation becomes *complex* (e.g. contains attributes or multiple elements), you’ll see a preview of expanded abbreviation every time caret is inside it. Hit <kbd>Tab</kbd> key *inside captured abbreviation* to expand it, hit <kbd>Esc</kbd> to remove mark from abbreviation so you can use <kbd>Tab</kbd> for expanding native ST snippets or insert tab character.
 
 ![Emmet abbreviation example](./images/emmet1.gif)
 


### PR DESCRIPTION
- Made some fixes to the text (mostly punctuation and missing words).
- Found a possible mistake in the options on line 238, related to reverting the behavior of <kbd>Tab</kbd> to Emmet v1 -> changed `auto_mark` to `tab_expand`.